### PR TITLE
Set the loss set currency to the specified value or default

### DIFF
--- a/batch_upload/README.md
+++ b/batch_upload/README.md
@@ -38,7 +38,7 @@ The general schema of the layer definitions data set is as follows:
 | Column Name | Description | Required | Default |
 |-|-|-|-|
 |`layer_id` | User-defined ID for the layer. This is used as a key to identify loss sets in the loss sets data set. | Yes | None |
-|`loss_set_currency` | Three-letter currency code of the currency of loss values in the loss set. | No | Fall-back to `currency`. |
+|`loss_set_ccy` | Three-letter currency code of the currency of loss values in the loss set. | No | Fall-back to `currency`. |
 |`loss_set_start_date` | For YELT loss sets, the absolute start date a reference for `sequence` offsets. | Yes for YELT loss sets. | None |
 |`layer_type` | `CatXL`, `QuotaShare`, `AggXL`, or `Generic` | Yes | None |
 |`description` | Value of the layer's description field to be stored. | No | None |

--- a/batch_upload/config.ini
+++ b/batch_upload/config.ini
@@ -35,7 +35,7 @@ reinstatement_brokerage  = Reinstatement Brokerage
 
 [layer_columns]
 layer_id = Layer ID
-loss_set_currency = LossSet Currency
+loss_set_ccy = LossSet Currency
 loss_set_start_date = LossSet StartDate
 layer_type = Layer Type
 description = Layer ID

--- a/batch_upload/sample_data/config.ini
+++ b/batch_upload/sample_data/config.ini
@@ -35,7 +35,7 @@ reinstatement_brokerage  = Reinstatement Brokerage
 
 [layer_columns]
 layer_id = Layer ID
-loss_set_currency = LossSet Currency
+loss_set_ccy = LossSet Currency
 loss_set_start_date = LossSet StartDate
 layer_type = Layer Type
 description = Layer ID


### PR DESCRIPTION
Prior to this, the tool ignored the `loss_set_currency` column configured in `config.ini` and always defaulted the loss set currency to the default value.