### PR TITLE
Fix scaled loss for exposure value

### DIFF
--- a/event_response_tool/layer_loss_duplicator/duplicate_layer_loss.py
+++ b/event_response_tool/layer_loss_duplicator/duplicate_layer_loss.py
@@ -138,15 +138,12 @@ class LayerLossDuplicator:
                     f"ELT {loss_set.id} without secondary uncertainty"
                 )
                 # Scale mean loss value
-                weighted_elt_df["LOSS"] = (
-                    weighted_elt_df.LOSS * weighted_elt_df.WEIGHT
-                )
+                scaled_loss = weighted_elt_df.LOSS * weighted_elt_df.WEIGHT
+                weighted_elt_df["LOSS"] = scaled_loss
                 weighted_elt_df["STDDEVC"] = 0
                 weighted_elt_df["STDDEVI"] = 0
                 # Set exposure value equal to the scaled loss
-                weighted_elt_df["EXPVALUE"] = (
-                    weighted_elt_df.LOSS * weighted_elt_df.WEIGHT
-                )
+                weighted_elt_df["EXPVALUE"] = scaled_loss
                 # Remove EventID and Weight columns
                 weighted_elt_df = weighted_elt_df.drop(
                     ["EVENTID", "WEIGHT"], axis=1


### PR DESCRIPTION
For Non-RMS ELT's, we set scaled loss value as the exposure value (so that loss value == exposure value). The change includes a fix for a minor bug that is causing the loss value to be greater than exposure value. 