### PR TITLE
Fix weight column issue

### DIFF
--- a/event_response_tool/layer_loss_duplicator/duplicate_layer_loss.py
+++ b/event_response_tool/layer_loss_duplicator/duplicate_layer_loss.py
@@ -114,8 +114,10 @@ class LayerLossDuplicator:
         event_id_column_in_weights = find_column(
             "event", self.event_weights_df.columns.tolist()
         )
+        weight_column = find_column("weight", self.event_weights_df.columns.tolist())
         self.event_weights_df = self.event_weights_df.rename(
-            columns={event_id_column_in_weights: event_id_column_in_elt}
+            columns={event_id_column_in_weights: event_id_column_in_elt,
+                     weight_column: "weight"}
         )
 
         # Perform left-join of weights table and loss set table.


### PR DESCRIPTION
Fix for a bug where when a different column name is used for event weight in the event weight CSV file, the tool would throw an error when processing the loss sets by multiplying the loss value and secondary uncertainty parameters by the event weight. 